### PR TITLE
Fix link to HTML’s email regular expression.

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -5447,7 +5447,7 @@ and the URL is `mailto:` followed by the email address.
 An [email address](#email-address), <a id="email-address"/>
 for these purposes, is anything that matches
 the [non-normative regex from the HTML5
-spec](http://www.whatwg.org/specs/web-apps/current-work/multipage/states-of-the-type-attribute.html#e-mail-state-%28type=email%29):
+spec](http://www.whatwg.org/specs/web-apps/current-work/multipage/forms.html#e-mail-state-%28type=email%29):
 
     /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?
     (?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/


### PR DESCRIPTION
The old URL seems to be no more and instead gives a page telling us:

> Links to the multipage version of the specification are unfortunately likely to break over time.
