### PR TITLE
Remove extra space before period

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -1854,7 +1854,7 @@ are defined:
 ## Paragraphs
 
 A sequence of non-blank lines that cannot be interpreted as other
-kinds of blocks forms a [paragraph](#paragraph) <a id="paragraph"/>.
+kinds of blocks forms a [paragraph](#paragraph). <a id="paragraph"/>
 The contents of the paragraph are the result of parsing the
 paragraph's raw content as inlines.  The paragraph's raw content
 is formed by concatenating the lines and removing initial and final


### PR DESCRIPTION
In other places where there's a comma after the linked word, the "a" element was also placed after it.
