### PR TITLE
Adding package.json for consumption via npmjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stmd",
   "version": "1.0.0-beta",
-  "description": "Standard Markdown",
+  "description": "CommonMark",
   "main": "js/stmd.js",
   "directories": {
     "man": "man"


### PR DESCRIPTION
This should get published via NPM so that people in the node world may easily consume this.

This package.json could do more, but I wanted to keep it sparse.  Set version to a `beta` so that when 1.0 is locked down, the package can be updated.
