### PR TITLE
runtests.pl: switch the order of arguments

### DIFF
--- a/runtests.pl
+++ b/runtests.pl
@@ -5,13 +5,13 @@ use Term::ANSIColor;
 use IO::Handle;
 use IPC::Open2;
 
-my $usage="runtests.pl PROGRAM SPEC\nSet ANSI_COLORS_DISABLED=1 if you redirect to a file.\nSet PATT='...' to restrict tests to sections matching a regex.\n";
+my $usage="runtests.pl SPEC PROGRAM\nSet ANSI_COLORS_DISABLED=1 if you redirect to a file.\nSet PATT='...' to restrict tests to sections matching a regex.\n";
 
-my $PROG=$ARGV[0];
-my $SPEC=$ARGV[1];
+my $SPEC = shift @ARGV;
+my @PROG = @ARGV;
 my $PATT=$ENV{'PATT'};
 
-if (!(defined $PROG && defined $SPEC)) {
+if (!(@PROG && defined $SPEC)) {
   print STDERR $usage;
   exit 1;
 }
@@ -69,7 +69,7 @@ sub dotest
   # We use → to indicate tab and ␣ space in the spec
   $markdown =~ s/→/\t/g;s/␣/ /g;
   $html =~ s/→/\t/g;s/␣/ /g;
-  open2(my $out, my $in, $PROG);
+  open2(my $out, my $in, @PROG);
   print $in $markdown;
   close $in;
   flush $out;


### PR DESCRIPTION
Putting the spec file first lets us consume all the other arguments as
the program to run. This makes it easier to use complex commands to run
the tests.

For example, my test program is: `perl -MText::Standard::Markdown -e'print markdown( join q{}, <> )'`

Leaving the args as they are, requires my test script to do:

``` perl
perl runtests.pl "perl -I"../lib" -MText::Markdown::Standard -e'markdown( join q{}, <STDIN> )'" spec.txt
```

With the args rearranged, I can do:

``` perl
perl runtests.pl spec.txt perl -I"../lib" -MText::Markdown::Standard -e'markdown( join "", <STDIN> )'
```

Removing the extra quotes that make the command with the inline Perl a little hairy.

And now that I write this, I see my first command has a bug in its quoting (but somehow still worked), which rearranging the args should help to prevent.
