### PR TITLE
only use colors when attached to a terminal

### DIFF
--- a/runtests.pl
+++ b/runtests.pl
@@ -16,6 +16,9 @@ if (!(defined $PROG && defined $SPEC)) {
   exit 1;
 }
 
+# Disable ANSI colors if we're not hooked up to a terminal
+$ENV{ANSI_COLORS_DISABLED} ||= !-t *STDOUT;
+
 my $passed = 0;
 my $failed = 0;
 my $skipped = 0;


### PR DESCRIPTION
If STDOUT is not hooked up to a terminal, automatically disable the
colors by setting the appropriate environment variable.
