### PR TITLE
Relocated `block-quote` anchor to fix Firefox rendering issue. Fixes #40

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -2002,8 +2002,8 @@ A [block quote marker](#block-quote-marker) <a id="block-quote-marker"/>
 consists of 0-3 spaces of initial indent, plus (a) the character `>` together
 with a following space, or (b) a single character `>` not followed by a space.
 
-The following rules define [block quotes](#block-quote):
 <a id="block-quote"/>
+The following rules define [block quotes](#block-quote):
 
 1.  **Basic case.**  If a string of lines *Ls* constitute a sequence
     of blocks *Bs*, then the result of appending a [block quote marker]


### PR DESCRIPTION
As referenced in #40, Firefox is having issues with self-closing `<a>'s` next to `<ol>'s`. To resolve this, I have relocated the `<a>` tag that was having issues:

![Firefox screenshot](https://cloud.githubusercontent.com/assets/902488/4147280/385cb10c-3416-11e4-90d0-8d212d1301a7.jpg)
