### PR TITLE
remove `require('util')` from /js/markdown

### DIFF
--- a/js/markdown
+++ b/js/markdown
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 var fs = require('fs');
-var util = require('util');
 var stmd = require('./stmd');
 
 file = process.argv[2] || '/dev/stdin';


### PR DESCRIPTION
The required module `util` does not seem to be used in the script.
