### PR TITLE
Fix the output of the JS `markdown` executable.

### DIFF
--- a/js/markdown
+++ b/js/markdown
@@ -11,5 +11,5 @@ fs.readFile(file, 'utf8', function(err, data) {
   }
   var parser   = new stmd.DocParser();
   var renderer = new stmd.HtmlRenderer();
-  console.log(renderer.render(parser.parse(data)));
+  process.stdout.write(renderer.render(parser.parse(data)));
 });


### PR DESCRIPTION
Previously, because of `console.log` semantics, if you ran:

```
make test PROG=js/markdown
```

You'd get a couple of errors caused by `console.log` calls putting `\n`
line breaks where they shouldn't. This fixes that by using
`process.stdout.write` instead of `console.log`.

This isn't something really important, but it's nice for all the
provided executables to pass the test suite.
