### PR TITLE
Resolve test.js line-ending sensitivity blocking running tests on Windows

### DIFF
--- a/js/test.js
+++ b/js/test.js
@@ -12,9 +12,9 @@ var passed = 0;
 var failed = 0;
 
 var showSpaces = function(s) {
-    var t = s;
-    return t.replace(/\t/g,'→')
-      .replace(/ /g,'␣');
+  var t = s;
+  return t.replace(/\t/g,'→')
+    .replace(/ /g,'␣');
 };
 
 fs.readFile('spec.txt', 'utf8', function(err, data) {


### PR DESCRIPTION
Also minor cleanup resolving JSHint warnings in test.js.
