### PR TITLE
replace Standard Markdown with CommonMark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-Standard markdown
+CommonMark
 =================
 
-Standard markdown is a [specification of markdown syntax][the spec],
+CommonMark is a [specification of markdown syntax][the spec],
 together with BSD3-licensed implementations (`stmd`) in C and javascript.
 
 The implementations

--- a/js/stmd.js
+++ b/js/stmd.js
@@ -1,4 +1,4 @@
-// stmd.js - "standard markdown" in javascript
+// stmd.js - CommomMark in javascript
 // Copyright (C) 2014 John MacFarlane
 // License: BSD3.
 

--- a/man/man1/stmd.1
+++ b/man/man1/stmd.1
@@ -10,7 +10,7 @@ stmd [\f[I]options\f[]] [file*]
 \f[C]stmd\f[] acts as a pipe, reading from stdin or from the specified
 files and writing to stdout.
 It converts markdown formatted plain text to HTML, using the conventions
-described in the standard markdown spec.
+described in the CommonMark spec.
 .SH OPTIONS
 .TP
 .B \f[C]\-\-ast\f[]

--- a/man/stmd.1.md
+++ b/man/stmd.1.md
@@ -17,8 +17,8 @@ stmd [*options*] [file\*]
 
 `stmd` acts as a pipe, reading from stdin or from the specified
 files and writing to stdout.  It converts markdown formatted plain
-text to HTML, using the conventions described in the standard
-markdown spec.
+text to HTML, using the conventions described in the CommonMark
+spec.
 
 # OPTIONS
 

--- a/narrative.md
+++ b/narrative.md
@@ -1,8 +1,8 @@
 ---
-title: Standard markdown
+title: CommonMark
 ...
 
-Standard markdown is a [specification of markdown
+CommonMark is a [specification of markdown
 syntax](http://jgm.github.io/stmd/spec.html), together with
 BSD3-licensed implementations (`stmd`) in C and javascript. The source
 for the spec and the two implementations can be found in [this

--- a/spec.txt
+++ b/spec.txt
@@ -1,5 +1,5 @@
 ---
-title: Standard Markdown Spec
+title: CommonMark Spec
 author:
 - John MacFarlane
 version: 1

--- a/src/main.c
+++ b/src/main.c
@@ -22,7 +22,7 @@ int main(int argc, char *argv[]) {
   for (i=1; i < argc; i++) {
     if (strcmp(argv[i], "--version") == 0) {
       printf("stmd %s", VERSION);
-      printf(" - standard markdown converter (c) 2014 John MacFarlane\n");
+      printf(" - CommonMark converter (c) 2014 John MacFarlane\n");
       exit(0);
     } else if ((strcmp(argv[i], "--help") == 0) ||
                (strcmp(argv[i], "-h") == 0)) {


### PR DESCRIPTION
I searched for "standard" and replaced "standard markdown" with "CommonMark".

I think this is something to be done.
