### PR TITLE
typo replacing CommonMark corrected

### DIFF
--- a/js/stmd.js
+++ b/js/stmd.js
@@ -1,4 +1,4 @@
-// stmd.js - CommomMark in javascript
+// stmd.js - CommonMark in javascript
 // Copyright (C) 2014 John MacFarlane
 // License: BSD3.
 


### PR DESCRIPTION
corrected typo (replaced CommonMark with CommomMark in one occurrence).
Many thanks to @rlidwka for pointing it out.
