### PR TITLE
Changes urls to use example.com

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -6146,3 +6146,5 @@ an `emph`.
 
 The document can be rendered as HTML, or in any other format, given
 an appropriate renderer.
+
+


### PR DESCRIPTION
As per RFC 2606 it is recommended to use example.com for sample urls in specifications.

One example is left using "foo+special@Bar.baz-bar0.com" because it is designed to demonstrate the complexity of email addresses that should be permitted.
