### PR TITLE
Implemented stack-based algorithm for matching emphasis (all tests pass)

### DIFF
--- a/src/inlines.c
+++ b/src/inlines.c
@@ -724,6 +724,15 @@ extern node_inl* parse_inlines_while(subject* subj, int (*f)(subject*))
 	node_inl* last = NULL;
 	while ((*f)(subj) && parse_inline(subj, first, &last)) {
 	}
+	
+	inline_stack* istack = subj->last_emphasis;
+	inline_stack* temp;
+	while (istack != NULL) {
+		temp = istack->previous;
+		free(istack);
+		istack = temp;
+	}
+	
 	return result;
 }
 


### PR DESCRIPTION
An updated version of #153, targeting `master` branch as you noted that `newemphasis` is no longer used.

The main difference is that `parse_inlines_while` now keeps track of both the head and tail of the list. Previously the variable named `last` actually pointed to the head, now it points to the tail and there is a new one `first` that points to the head.

With this update the C implementation **passes all 450 tests**. There is no backtracking involved so performance should be the same as before, if not better since there is no need for recursion anymore.

Note on one of the additional tests you mentioned in #153:
- `*a [b*b] c*` is parsed as `<em>a [b*b] c</em>` because the current `handle_left_bracket` implementation parses the contents of the brackets as a separate subject, in effect `[ ]` takes precedence over `* *` in this case. If this is not intended, `handle_left_bracket` would have to be changed.

I will also plan to write a longer comment on #154 how this algorithm could be extended to support any other inline elements like `^...^` or `~~...~~`.
