### PR TITLE
Fixed example 4

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -286,6 +286,10 @@ ___
 <hr />
 .
 
+Note that the first two lines could also be interpreted as a [setext
+header](#setext-header). In ambiguous cases like these, the horizontal rule
+takes precedence.
+
 Wrong characters:
 
 .


### PR DESCRIPTION
Since setext takes precedence, the current example 4 should render as

<h2>***</h2>

<hr />

By moving the dashes on top it's no longer a setext.
Fixes #31 .
