### PR TITLE
Typo in runtests.pl

### DIFF
--- a/runtests.pl
+++ b/runtests.pl
@@ -81,7 +81,7 @@ sub dotest
   waitpid($pid, 0);
   $html   = &tidy($html);
   $actual = &tidy($actual);
-  $actual =~ s/\&#39;/'/;
+  $actual =~ s/\&#39;/'/g;
 
   if ($actual eq $html) {
     print colored("✓", "green");


### PR DESCRIPTION
The test runner replaced `&#39;` in the output with `'`, but the `g` flag was missing so only one substitution was performed and the output wasn't correctly normalized.
