### PR TITLE
Add -fPIC to linker options.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CFLAGS?=-g -O3 -Wall -Wextra -std=c99 -Isrc -Wno-missing-field-initializers -fPIC $(OPTCFLAGS)
-LDFLAGS?=-g -O3 -Wall -Werror $(OPTLDFLAGS)
+LDFLAGS?=-g -O3 -Wall -Werror -fPIC $(OPTLDFLAGS)
 SRCDIR?=src
 DATADIR?=data
 BENCHINP?=README.md


### PR DESCRIPTION
I was getting compilation errors on 64-bit Linux. This seems to fix it, but I haven't looked at the bug in depth.

Tested with gcc (GCC) 4.9.1 20140903 (prerelease) and clang version 3.5.0 (tags/RELEASE_350/final) on Arch Linux.

Fixes #179.
