### PR TITLE
Added Unicode Bullet character (U+2022) as valid list item indicator

### DIFF
--- a/js/lib/blocks.js
+++ b/js/lib/blocks.js
@@ -151,7 +151,7 @@ var parseListMarker = function(ln, offset) {
     if (rest.match(reHrule)) {
         return null;
     }
-    if ((match = rest.match(/^[*+-•]( +|$)/))) {
+    if ((match = rest.match(/^[\u2022*+-]( +|$)/))) {
         spaces_after_marker = match[1].length;
         data.type = 'Bullet';
         data.bullet_char = match[0][0];
@@ -326,7 +326,7 @@ var incorporateLine = function(ln, line_number) {
            container.t != 'IndentedCode' &&
            container.t != 'HtmlBlock' &&
            // this is a little performance optimization:
-           matchAt(/^[ #`~*•+_=<>0-9-]/,ln,offset) !== -1) {
+           matchAt(/^[ #`~*\u2022+_=<>0-9-]/,ln,offset) !== -1) {
 
         match = matchAt(/[^ ]/, ln, offset);
         if (match === -1) {

--- a/js/lib/blocks.js
+++ b/js/lib/blocks.js
@@ -151,7 +151,7 @@ var parseListMarker = function(ln, offset) {
     if (rest.match(reHrule)) {
         return null;
     }
-    if ((match = rest.match(/^[*+-]( +|$)/))) {
+    if ((match = rest.match(/^[*+-•]( +|$)/))) {
         spaces_after_marker = match[1].length;
         data.type = 'Bullet';
         data.bullet_char = match[0][0];
@@ -326,7 +326,7 @@ var incorporateLine = function(ln, line_number) {
            container.t != 'IndentedCode' &&
            container.t != 'HtmlBlock' &&
            // this is a little performance optimization:
-           matchAt(/^[ #`~*+_=<>0-9-]/,ln,offset) !== -1) {
+           matchAt(/^[ #`~*•+_=<>0-9-]/,ln,offset) !== -1) {
 
         match = matchAt(/[^ ]/, ln, offset);
         if (match === -1) {

--- a/spec.txt
+++ b/spec.txt
@@ -2479,7 +2479,7 @@ A [list marker](@list-marker) is a
 marker](#ordered-list-marker).
 
 A [bullet list marker](@bullet-list-marker)
-is a `-`, `+`, or `*` character.
+is a `-`, `+`, `*` or `•` (U+2022) character.
 
 An [ordered list marker](@ordered-list-marker)
 is a sequence of one of more digits (`0-9`), followed by either a
@@ -3324,7 +3324,7 @@ Two list items are [of the same type](@of-the-same-type)
 if they begin with a [list
 marker](#list-marker) of the same type.  Two list markers are of the
 same type if (a) they are bullet list markers using the same character
-(`-`, `+`, or `*`) or (b) they are ordered list numbers with the same
+(`-`, `+`, `*` or `•`) or (b) they are ordered list numbers with the same
 delimiter (either `.` or `)`).
 
 A list is an [ordered list](@ordered-list)
@@ -3351,6 +3351,7 @@ Changing the bullet or ordered list delimiter starts a new list:
 - foo
 - bar
 + baz
+• cat
 .
 <ul>
 <li>foo</li>
@@ -3358,6 +3359,9 @@ Changing the bullet or ordered list delimiter starts a new list:
 </ul>
 <ul>
 <li>baz</li>
+</ul>
+<ul>
+<li>cat</li>
 </ul>
 .
 

--- a/src/blocks.c
+++ b/src/blocks.c
@@ -316,8 +316,14 @@ static int parse_list_marker(chunk *input, int pos, struct ListData ** dataptr)
 	startpos = pos;
 	c = peek_at(input, pos);
 
-	if ((c == '*' || c == '-' || c == '+') && !scan_hrule(input, pos)) {
+	// unicode bullet character U+2022 is represented in UTF-8 as E2 80 A2
+	if (c == '+' 
+	    || (c == 0xe2 && peek_at(input, pos + 1) == 0x80 && peek_at(input, pos + 2) == 0xa2)
+	    || ((c == '*' || c == '-') && !scan_hrule(input, pos))) {
 		pos++;
+		if (c == 0xe2) {
+			pos += 2;
+		}
 		if (!isspace(peek_at(input, pos))) {
 			return 0;
 		}


### PR DESCRIPTION
There has been a [discussion](http://talk.commonmark.org/t/unicode-character-bullet-u-2022/397) where various reasons have been given why it would be nice if this character would be supported. For me the main reason is the ability to copy-paste (copying lists from, for example, Word or IE adds this character) without the need to manually change the bullets.

The PR includes change to the spec.txt, JS implementation and C implementation.

All tests pass for both JS and C implementation.
