### PR TITLE
Rename include guards for consistency and to avoid reserved identifiers

### DIFF
--- a/src/bench.h
+++ b/src/bench.h
@@ -1,5 +1,6 @@
-#ifndef __BENCH_H__
-#define __BENCH_H__
+#ifndef CMARK_BENCH_H
+#define CMARK_BENCH_H
+
 #include <stdio.h>
 #include <time.h>
 
@@ -22,4 +23,5 @@ float _cmark_save_time;
 #define start_timer()
 #define end_timer(M)
 #endif
+
 #endif

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -1,5 +1,5 @@
-#ifndef INCLUDE_buffer_h__
-#define INCLUDE_buffer_h__
+#ifndef CMARK_BUFFER_H
+#define CMARK_BUFFER_H
 
 #include <stdbool.h>
 #include <stddef.h>

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -1,5 +1,5 @@
-#ifndef _CHUNK_H_
-#define _CHUNK_H_
+#ifndef CMARK_CHUNK_H
+#define CMARK_CHUNK_H
 
 #include <string.h>
 #include <ctype.h>

--- a/src/cmark.h
+++ b/src/cmark.h
@@ -1,5 +1,5 @@
-#ifndef _CMARK_H_
-#define _CMARK_H_
+#ifndef CMARK_H
+#define CMARK_H
 
 #include <stdbool.h>
 #include <stdio.h>

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,5 +1,5 @@
-#ifndef __debug_h__
-#define __debug_h__
+#ifndef CMARK_DEBUG_H
+#define CMARK_DEBUG_H
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>

--- a/src/html/houdini.h
+++ b/src/html/houdini.h
@@ -1,5 +1,5 @@
-#ifndef __HOUDINI_H__
-#define __HOUDINI_H__
+#ifndef CMARK_HOUDINI_H
+#define CMARK_HOUDINI_H
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/inlines.h
+++ b/src/inlines.h
@@ -1,5 +1,5 @@
-#ifndef _INLINES_H_
-#define _INLINES_H_
+#ifndef CMARK_INLINES_H
+#define CMARK_INLINES_H
 
 unsigned char *cmark_clean_url(cmark_chunk *url);
 unsigned char *cmark_clean_title(cmark_chunk *title);

--- a/src/references.h
+++ b/src/references.h
@@ -1,5 +1,5 @@
-#ifndef _REFERENCES_H_
-#define _REFERENCES_H_
+#ifndef CMARK_REFERENCES_H
+#define CMARK_REFERENCES_H
 
 #define REFMAP_SIZE 16
 

--- a/src/utf8.h
+++ b/src/utf8.h
@@ -1,5 +1,5 @@
-#ifndef _H_cmark_UTF8_
-#define _H_cmark_UTF8_
+#ifndef CMARK_UTF8_H
+#define CMARK_UTF8_H
 
 #include <stdint.h>
 #include "buffer.h"


### PR DESCRIPTION
The C99 spec states in section 7.1.3 ("Reserved identifiers"):

> All identifiers that begin with an underscore and either an uppercase letter or another underscore are always reserved for any use.
> ...
> If the program declares or defines an identifier in a context in which it is reserved (other than as allowed by 7.1.4), or defines a reserved identifier as a macro name, the behavior is undefined.
