### PR TITLE
Fix Issue 202 - Catch RangeError thrown by native String.fromCodePoint (js)

### DIFF
--- a/js/lib/from-code-point.js
+++ b/js/lib/from-code-point.js
@@ -2,7 +2,16 @@
 /*! http://mths.be/fromcodepoint v0.2.1 by @mathias */
 if (String.fromCodePoint) {
 
-  module.exports = String.fromCodePoint;
+    module.exports = function (_) {
+        try {
+            return String.fromCodePoint(_);
+        } catch (e) {
+            if (e instanceof RangeError) {
+                return String.fromCharCode(0xFFFD);
+            }
+            throw e;
+        }
+    }
 
 } else {
 


### PR DESCRIPTION
When using a JS engine that provides a native String.fromCodePoint ES6 implementation (e.g. SpiderMonkey), a RangeError is thrown if the codepoint is invalid.

When adding the from-code-point.js polyfill, the js implementation was modified in order to handle invalid code point by returning the 0xFFFD placeholder glyph. So this is not a real "polyfill", but an specific implementation (adapted to the parser needs).

So, if a native String.fromCodePoint implementation is availbale, the fromCodePoint function should catch the RangeError and return the 0xFFFD placeholder glyph.
