### PR TITLE
Fix display of triple-backtick to be cross-renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ the canonical syntax description:
 -   The start number of an ordered list is significant.
 
 -   [Fenced code blocks](http://jgm.github.io/CommonMark/spec.html#fenced-code-blocks) are supported, delimited by either
-    backticks (` ``` `) or tildes (` ~~~ `).
+    backticks (<code>\`\`\`</code>) or tildes (` ~~~ `).
 
 In all of this, I have been guided by eight years experience writing
 Markdown implementations in several languages, including the first


### PR DESCRIPTION
GitHub Flavored Markdown (where this README.md is rendered) was showing the triple tick as <code> </code>`<code> </code>.

This fixes it to correctly display 3 backtick characters when rendered <code>```</code>

Tested in reference implementation, Github, and dillinger.io
