### PR TITLE
Fix .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,12 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
 
-[{*.c,Makefile}]
+[*.{c,h}]
+trim_trailing_whitespace = true
+indent_style = tab
+indent_size = 8
+
+[Makefile]
 trim_trailing_whitespace = true
 indent_style = tab
 indent_size = 8


### PR DESCRIPTION
It seems that the vim plugin doesn't support globs in braces.
