### PR TITLE
Don't allow insert_{before|after} root node

### DIFF
--- a/api_test/main.c
+++ b/api_test/main.c
@@ -298,6 +298,10 @@ create_tree(test_batch_runner *runner)
 	cmark_node *doc = cmark_node_new(CMARK_NODE_DOCUMENT);
 
 	cmark_node *p = cmark_node_new(CMARK_NODE_PARAGRAPH);
+	OK(runner, !cmark_node_insert_before(doc, p),
+	   "insert before root fails");
+	OK(runner, !cmark_node_insert_after(doc, p),
+	   "insert after root fails");
 	OK(runner, cmark_node_append_child(doc, p), "append1");
 	INT_EQ(runner, cmark_node_check(doc, NULL), 0, "append1 consistent");
 	OK(runner, cmark_node_parent(p) == doc, "node_parent");

--- a/src/node.c
+++ b/src/node.c
@@ -436,7 +436,7 @@ cmark_node_unlink(cmark_node *node) {
 int
 cmark_node_insert_before(cmark_node *node, cmark_node *sibling)
 {
-	if (!S_can_contain(node->parent, sibling)) {
+	if (!node->parent || !S_can_contain(node->parent, sibling)) {
 		return 0;
 	}
 
@@ -467,7 +467,7 @@ cmark_node_insert_before(cmark_node *node, cmark_node *sibling)
 int
 cmark_node_insert_after(cmark_node *node, cmark_node *sibling)
 {
-	if (!S_can_contain(node->parent, sibling)) {
+	if (!node->parent || !S_can_contain(node->parent, sibling)) {
 		return 0;
 	}
 


### PR DESCRIPTION
This can be changed if support for node lists is added to the public API.
