### PR TITLE
Push parser interface

### DIFF
--- a/src/cmark.h
+++ b/src/cmark.h
@@ -176,7 +176,7 @@ CMARK_EXPORT
 cmark_node *cmark_parser_finish(cmark_parser *parser);
 
 CMARK_EXPORT
-void cmark_parser_process_line(cmark_parser *parser, const char *buffer, size_t bytes);
+void cmark_parser_push(cmark_parser *parser, const char *buffer, size_t len);
 
 CMARK_EXPORT
 cmark_node *cmark_parse_document(const char *buffer, size_t len);

--- a/src/main.c
+++ b/src/main.c
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
 	int *files;
 	char buffer[4096];
 	cmark_parser *parser;
-	size_t offset;
+	size_t bytes;
 	cmark_node *document;
 
 	parser = cmark_parser_new();
@@ -69,9 +69,8 @@ int main(int argc, char *argv[])
 		}
 
 		start_timer();
-		while (fgets((char *)buffer, sizeof(buffer), fp)) {
-			offset = strlen((char *)buffer);
-			cmark_parser_process_line(parser, buffer, offset);
+		while ((bytes = fread(buffer, 1, sizeof(buffer), fp)) > 0) {
+			cmark_parser_push(parser, buffer, bytes);
 		}
 		end_timer("processing lines");
 
@@ -85,9 +84,8 @@ int main(int argc, char *argv[])
 		exit(0);
 		*/
 
-		while (fgets((char *)buffer, sizeof(buffer), stdin)) {
-			offset = strlen((char *)buffer);
-			cmark_parser_process_line(parser, buffer, offset);
+		while ((bytes = fread(buffer, 1, sizeof(buffer), stdin)) > 0) {
+			cmark_parser_push(parser, buffer, bytes);
 		}
 	}
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -17,6 +17,7 @@ struct cmark_parser {
 	struct cmark_node* current;
 	int line_number;
 	cmark_strbuf *curline;
+	cmark_strbuf *linebuf;
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
Replace `cmark_parser_process_line` with `cmark_parser_push` that takes
arbitrary chunks of data. Also fixes #211.
