### PR TITLE
fixed python script

### DIFF
--- a/test/spec_tests.py
+++ b/test/spec_tests.py
@@ -46,7 +46,7 @@ def do_test(test, normalize):
         else:
             print_test_header(test['section'], test['example'], test['start_line'], test['end_line'])
             sys.stdout.write(test['markdown'])
-            expected_html_lines = '\n'.split(expected_html)
+            expected_html_lines = expected_html.splitlines(True)
             actual_html_lines = actual_html.splitlines(True)
             for diffline in unified_diff(expected_html_lines, actual_html_lines,
                             "expected HTML", "actual HTML"):


### PR DESCRIPTION
all these variables are not defined and have to be extracted from `test`.

Running the script this way resulted in error:

```
python cmm/test/spec_tests.py --spec cmm/spec.txt --program "./bin/markdown --flavor=common"
Traceback (most recent call last):
  File "cmm/test/spec_tests.py", line 137, in <module>
    if do_tests(cmark, tests, args.pattern, args.normalize):
  File "cmm/test/spec_tests.py", line 114, in do_tests
    result = do_test(test, normalize)
  File "cmm/test/spec_tests.py", line 47, in do_test
    print_test_header(headertext, example_number,start_line,end_line)
NameError: global name 'headertext' is not defined

```
