### PR TITLE
Fix last_line_blank logic

### DIFF
--- a/src/blocks.c
+++ b/src/blocks.c
@@ -789,8 +789,8 @@ S_process_line(cmark_parser *parser, const unsigned char *buffer, size_t bytes)
 	container->last_line_blank = (blank &&
 			container->type != NODE_BLOCK_QUOTE &&
 			container->type != NODE_HEADER &&
-			(container->type != NODE_CODE_BLOCK &&
-			 container->as.code.fenced) &&
+			!(container->type == NODE_CODE_BLOCK &&
+				container->as.code.fenced) &&
 			!(container->type == NODE_LIST_ITEM &&
 				container->first_child == NULL &&
 				container->start_line == parser->line_number));


### PR DESCRIPTION
The broken last_line_blank logic could lead to random failures in the
API tests.
