### PR TITLE
Expose failure to normalize whitespaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ before_install:
 script:
  - make testtarball
  - PROG=`ls cmark-*.*/build/src/cmark` make leakcheck
+ - python -m doctest test/normalize.py

--- a/test/normalize.py
+++ b/test/normalize.py
@@ -115,8 +115,12 @@ def normalize_html(html):
     Return normalized form of HTML which ignores insignificant output
     differences:
 
-    * Multiple inner whitespaces are collapsed to a single space (except
-      in pre tags).
+    Multiple inner whitespaces are collapsed to a single space (except
+    in pre tags):
+
+        >>> normalize_html("<p>a  \t\nb</p>")
+        u'<p>a b</p>'
+
     * Outer whitespace (outside block-level tags) is removed.
     * Self-closing tags are converted to open tags.
     * Attributes are sorted and lowercased.


### PR DESCRIPTION
Run with:

```
python -m doctest normalize.py
```

I found this while trying the CommonMark test suite with `pandoc`:

```
./test/spec_tests.py --program pandoc
```

Also I recommend that we add a bunch more unit doctests for that function similarly to: https://github.com/karlcow/markdown-testsuite/blob/639cd234d71ca81956b61ff7876f37c3cdc5c043/run-tests.py#L75 because it is very tricky to implement.
