### PR TITLE
Match paragraph spec to dingus behavior

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -3038,7 +3038,7 @@ kinds of blocks forms a [paragraph](@).
 The contents of the paragraph are the result of parsing the
 paragraph's raw content as inlines.  The paragraph's raw content
 is formed by concatenating the lines and removing initial and final
-[whitespace].
+[Unicode whitespace].
 
 A simple example with two paragraphs:
 


### PR DESCRIPTION
The CommonMark dingus implementation strips unicode whitespace from
the start and end of paragraphs, so this should be clarified in the spec.

[Example link](http://spec.commonmark.org/dingus/?text=%E1%9A%80o%E1%9A%80o%E1%9A%80%0A%E1%9A%80o%E1%9A%80o%E1%9A%80)

Each "space" character in this example is "U+1680, OGHAM SPACE MARK", chosen from the list of Unicode whitespace characters.  The leading and final instances are trimmed from the paragraph, so the spec should at least match that behavior.

Or, if this isn't the intended behavior, I guess the dingus implementation needs to be updated