### PR TITLE
Add spec.json generator to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ spec.tex: spec.txt tools/template.latex
 spec.pdf: spec.tex
 	xelatex $<
 
+spec.json: spec.txt
+	python3 test/spec_tests.py --dump-tests < $< > $@
+
 npm:
 	# Do a sanity check first on versions
 	grep -q '"version": *"$(SPECVERSION)' package.json && \


### PR DESCRIPTION
Having this in the MakeFile makes it that much easier to produce the `spec.json` in a way that is analogous to the other forms of the spec document.