### PR TITLE
Info string is trimmed of all whitespace

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -1584,7 +1584,7 @@ begins with a code fence, indented no more than three spaces.
 
 The line with the opening code fence may optionally contain some text
 following the code fence; this is trimmed of leading and trailing
-spaces and called the [info string](@).
+whitespace and called the [info string](@).
 The [info string] may not contain any backtick
 characters.  (The reason for this restriction is that otherwise
 some inline code would be incorrectly interpreted as the

--- a/spec.txt
+++ b/spec.txt
@@ -527,7 +527,7 @@ Markdown document.
 
 A line consisting of 0-3 spaces of indentation, followed by a sequence
 of three or more matching `-`, `_`, or `*` characters, each followed
-optionally by any number of spaces, forms a
+optionally by any number of spaces or tabs, forms a
 [thematic break](@).
 
 ```````````````````````````````` example


### PR DESCRIPTION
As noted in https://github.com/github/cmark/issues/60, the info string is not only trimmed of "spaces" (U+0020) but indeed all whitespace.  Update the spec to reflect this.

Likewise, "spaces" is changed to "spaces or tabs" following a thematic break, per the scanner.