### PR TITLE
Replace image 'url' with 'destination' in DTD

### DIFF
--- a/CommonMark.dtd
+++ b/CommonMark.dtd
@@ -67,7 +67,7 @@
 
 <!ELEMENT image (%inline;)*>
 <!ATTLIST image
-          url CDATA #REQUIRED
+          destination CDATA #REQUIRED
           title CDATA #IMPLIED>
 
 <!ELEMENT html_inline (#PCDATA)>


### PR DESCRIPTION
The DTD defines a 'url' attribute for an image, however both cmark and CommonMark.js appear to use 'destination' instead (which is also consistent with a link).

http://spec.commonmark.org/dingus/
```
![foo](/url "title")
```

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE document SYSTEM "CommonMark.dtd">

<document xmlns="http://commonmark.org/xml/1.0">
  <paragraph>
    <image destination="/url" title="title">
      <text>foo</text>
    </image>
  </paragraph>
</document>
```

This MR updates the DTD to use 'destination' instead of 'url'. I couldn't see any other references in the spec indicating which attribute is actually correct, but if it is the case that cmark/commonmark.js are actually incorrect and not following the DTD, please close this. 