### PR TITLE
Fix a typo in spec.txt

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -2069,7 +2069,7 @@ _world_.
 </td></tr></table>
 ````````````````````````````````
 
-In this case, the HTML block is terminated by the newline — the `**hello**`
+In this case, the HTML block is terminated by the newline — the `**Hello**`
 text remains verbatim — and regular parsing resumes, with a paragraph,
 emphasised `world` and inline and block HTML following.
 


### PR DESCRIPTION
Example 116 is:
```
<table><tr><td>
<pre>
**Hello**,

_world_.
</pre>
</td></tr></table>
```

But `**Hello**` is lowercased in the document.