### PR TITLE
adds aliases for heading types

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -749,7 +749,7 @@ If you want a thematic break in a list item, use a different bullet:
 
 ## ATX headings
 
-An [ATX heading](@)
+An [ATX heading](@) or [prefixed heading](@)
 consists of a string of characters, parsed as inline content, between an
 opening sequence of 1--6 unescaped `#` characters and an optional
 closing sequence of any number of unescaped `#` characters.
@@ -968,10 +968,14 @@ ATX headings can be empty:
 <h3></h3>
 ````````````````````````````````
 
+Note that MediaWiki markup uses the equals sign `=` for ATX-like headings instead 
+and uses the number sign `#` for ordered list items. 
+This constitutes one major incompatibility between CommonMark and MediaWiki.
+
 
 ## Setext headings
 
-A [setext heading](@) consists of one or more
+A [setext heading](@) or [underlined heading](@) consists of one or more
 lines of text, each containing at least one [non-whitespace
 character], with no more than 3 spaces indentation, followed by
 a [setext heading underline].  The lines of text must be such
@@ -983,9 +987,9 @@ interpretable as a [code fence], [ATX heading][ATX headings],
 
 A [setext heading underline](@) is a sequence of
 `=` characters or a sequence of `-` characters, with no more than 3
-spaces indentation and any number of trailing spaces.  If a line
-containing a single `-` can be interpreted as an
-empty [list items], it should be interpreted this way
+spaces indentation and any number of trailing spaces.  
+If a line containing a single `-` can be interpreted as an
+empty [list item][list items], it *should* be interpreted this way
 and not as a [setext heading underline].
 
 The heading is a level 1 heading if `=` characters are used in
@@ -1307,6 +1311,11 @@ One can find four different interpretations:
 3. paragraph "Foo bar --- baz"
 4. heading "Foo bar", paragraph "baz"
 
+Interpretation 3 does not comply with the CommonMark rule 
+that both a [thematic break] and a setext heading 
+can interrupt a paragraph, 
+i.e. they do not need a blank line before or after.
+
 We find interpretation 4 most natural, and interpretation 4
 increases the expressive power of CommonMark, by allowing
 multiline headings.  Authors who want interpretation 1 can
@@ -1588,7 +1597,7 @@ spaces and called the [info string](@).
 The [info string] may not contain any backtick
 characters.  (The reason for this restriction is that otherwise
 some inline code would be incorrectly interpreted as the
-beginning of a fenced code block.)
+beginning of a fenced code block.) 
 
 The content of the code block consists of all subsequent lines, until
 a closing [code fence] of the same type as the code block


### PR DESCRIPTION
fixes #516
- ATX heading = prefixed heading
- setext heading = underlined heading
