### PR TITLE
Fix dingus link when double clicking Markdown code

### DIFF
--- a/tools/template.html
+++ b/tools/template.html
@@ -108,7 +108,7 @@ $$(document).ready(function() {
     });
   });
   $$("code.language-markdown").dblclick(function(e) { window.open('/dingus/?text=' +
-      encodeURIComponent($$(this).find('code').text()));
+      encodeURIComponent($$(this).text()));
   });
 });
 </script>


### PR DESCRIPTION
Currently, double clicking on Markdown code on https://spec.commonmark.org/0.28/ always opens https://spec.commonmark.org/dingus/?text= without content prefill. This PR fixes that bug.