### PR TITLE
make_spec.lua: fix migration of children nodes in create_anchors

### DIFF
--- a/tools/make_spec.lua
+++ b/tools/make_spec.lua
@@ -167,9 +167,13 @@ local create_anchors = function(doc, meta, to)
           end
         end
       end
+      local children = {};
       while child do
-        node_append_child(anchor, child)
+        children[#children + 1] = child
         child = cmark.node_next(child)
+      end
+      for _,child in ipairs(children) do
+        node_append_child(anchor, child)
       end
       cmark.node_insert_before(cur, anchor)
       cmark.node_unlink(cur)

--- a/tools/make_spec.lua
+++ b/tools/make_spec.lua
@@ -30,8 +30,8 @@ local extract_references = function(doc)
     if not entering and
         ((node_type == cmark.NODE_LINK and cmark.node_get_url(cur) == '@') or
           node_type == cmark.NODE_HEADING) then
-      local children = cmark.node_first_child(cur)
-      local label = trim(cmark.render_commonmark(children, OPT_DEFAULT, 0))
+      local child = cmark.node_first_child(cur)
+      local label = trim(cmark.render_commonmark(child, OPT_DEFAULT, 0))
       local ident = to_identifier(label)
       if refs[label] then
         warn("duplicate reference " .. label)
@@ -118,8 +118,8 @@ local create_anchors = function(doc, meta, to)
           node_type == cmark.NODE_HEADING) then
 
       local anchor
-      local children = cmark.node_first_child(cur)
-      local label = trim(cmark.render_commonmark(children, OPT_DEFAULT, 0))
+      local child = cmark.node_first_child(cur)
+      local label = trim(cmark.render_commonmark(child, OPT_DEFAULT, 0))
       local ident = to_identifier(label)
       if node_type == cmark.NODE_LINK then
         if format == 'latex' then
@@ -167,9 +167,9 @@ local create_anchors = function(doc, meta, to)
           end
         end
       end
-      while children do
-        node_append_child(anchor, children)
-        children = cmark.node_next(children)
+      while child do
+        node_append_child(anchor, child)
+        child = cmark.node_next(child)
       end
       cmark.node_insert_before(cur, anchor)
       cmark.node_unlink(cur)
@@ -289,4 +289,3 @@ else
   io.stderr:write(msg)
   os.exit(1)
 end
-


### PR DESCRIPTION
Currently, when migrating the children of a node to a new one, children are moved as they are iterated via `cmark_node_next`; however, when a child is moved under the new node, its next relationship with its sibling is broken, so in fact at most one child is migrated, and the rest are lost. This resulted in cases like

    [Decimal numeric character
    references](@)
    consist of...

(note the softbreak) being eventually rendered as

    <a ...>Decimal numeric character</a>
    consist of...

The bug is fixed in this PR.