### PR TITLE
Change link title/destination example to match spec

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -2900,8 +2900,7 @@ whitespace:
 
 [foo]
 .
-<p>[foo]: <bar>(baz)</p>
-<p>[foo]</p>
+<p><a href="&lt;bar&gt;(baz)">foo</a></p>
 ````````````````````````````````
 
 


### PR DESCRIPTION
I don't really think this is good behavior described by the spec, but the example

https://github.com/commonmark/CommonMark/blob/b7651e4f8b9bdcccd38e7895997360dc11489527/spec.txt#L2895-L2905

doesn't conform to the current spec. The current `master` version says:

https://github.com/commonmark/CommonMark/blob/b7651e4f8b9bdcccd38e7895997360dc11489527/spec.txt#L7313-L7324

The first case doesn't apply because there are additional characters after the `>`.

But the second case totally matches, so the result should be (according to the spec) a link, but the link destination is probably not what was expected.

I think it would be much better to change the spec to disallow the link destination to start with `<` in the second case.
Are there any possible link destinations in the wild that really should start with `<` (and not end with `>`)?
I guess not.

I guess that this is just a variation on my older issue #473, but this example here is actually breaking unit tests of conforming (to the current `master` spec) implementations ...