### PR TITLE
fix typo in spec (issue #555)

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -2003,15 +2003,15 @@ Closing code fences cannot have [info strings]:
 An [HTML block](@) is a group of lines that is treated
 as raw HTML (and will not be escaped in HTML output).
 
-There are seven kinds of [HTML block], which can be defined
-by their start and end conditions.  The block begins with a line that
-meets a [start condition](@) (after up to three spaces
-optional indentation).  It ends with the first subsequent line that
-meets a matching [end condition](@), or the last line of
-the document or other [container block](#container-blocks)), if no
-line is encountered that meets the [end condition].  If the first line
-meets both the [start condition] and the [end condition], the block
-will contain just that line.
+There are seven kinds of [HTML block], which can be defined by their
+start and end conditions.  The block begins with a line that meets a
+[start condition](@) (after up to three spaces optional indentation).
+It ends with the first subsequent line that meets a matching [end
+condition](@), or the last line of the document, or the last line of
+the [container block](#container-blocks) containing the current HTML
+block, if no line is encountered that meets the [end condition].  If
+the first line meets both the [start condition] and the [end
+condition], the block will contain just that line.
 
 1.  **Start condition:**  line begins with the string `<script`,
 `<pre`, or `<style` (case-insensitive), followed by whitespace,


### PR DESCRIPTION
Remove spurious parenthesis, rephrase for clarity (issue [#555](https://github.com/commonmark/CommonMark/issues/555)).

More lines seem changed (because `emacs fill-paragraph`), 
but only one sentence was modified. I'll change the pull request 
if this is a problem.