### PR TITLE
Correct the description of an `info string`

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -1613,10 +1613,9 @@ A fenced code block may interrupt a paragraph, and does not require
 a blank line either before or after.
 
 The content of a code fence is treated as literal text, not parsed
-as inlines.  The first word of the [info string] is typically used to
-specify the language of the code sample, and rendered in the `class`
-attribute of the `code` tag.  However, this spec does not mandate any
-particular treatment of the [info string].
+as inlines.  The first word of the [info string] is used to
+specify the language of the code sample, and is rendered in the `class`
+attribute of the `code` tag after the prefix `language-`.
 
 Here is a simple example with backticks:
 


### PR DESCRIPTION
The spec does mandate a particular treatment of the `info string` and this statement was a contradiction.

The mandate is in example 111:
> An info string can be provided after the opening code fence. Opening and closing spaces will be stripped, and the first word, prefixed with language-, is used as the value for the class attribute of the code element within the enclosing pre element.