### PR TITLE
Allow optional namespace before tag name.

### DIFF
--- a/spec.txt
+++ b/spec.txt
@@ -8914,6 +8914,10 @@ so custom tags (and even, say, DocBook tags) may be used.
 
 Here is the grammar for tags:
 
+An optional [namespace](@) consists of an ASCII letter
+followed by zero or more ASCII letters, digits, or
+hyphens (`-`), ending with a colon (`:`).
+
 A [tag name](@) consists of an ASCII letter
 followed by zero or more ASCII letters, digits, or
 hyphens (`-`).


### PR DESCRIPTION
This is a proposed change to the markdown spec to allow namespaces within HTML tags.

It should be noted:

- Our tag name definition is a subset of allowable tag names as per https://www.w3.org/TR/xml-names/#ns-decl
- HTML5 disallows namespaces in tags, while XML/XHTML allows it.
- The attribute name definition in the spec already allows namespaces.
- The chance of impact to existing markdown documents is extremely low.
- Some [parsers already allow namespaces in tags](https://babelmark.github.io/?text=%3Cfoo%3Abar%3E%0A++Baz%0A%3C%2Ffoo%3Abar%3E).

The motivation for this is to allow XML to pass through markdown documents unchanged. This can include things like SVG, MathML, etc. In my particular case, I have a post processing step which expands namespaced tags into templates.

An alternative to this proposal could be:

```
A [tag name](@) consists of an ASCII letter
followed by zero or more ASCII letters, digits, 
hyphens (`-`) or colons (`:`).
```

That proposal is more similar to how attributes are defined, and easier to parse, but also not completely accurate w.r.t. the XMLNS specification.

See https://github.com/gjtorikian/commonmarker/pull/123 for a potential implementation.

cc @kivikakk 