### PR TITLE
Fix DTD syntax error

### DIFF
--- a/CommonMark.dtd
+++ b/CommonMark.dtd
@@ -46,7 +46,8 @@
 
 <!-- inline elements -->
 
-<!ELEMENT text (#PCDATA)
+<!ELEMENT text (#PCDATA)>
+<!ATTLIST text
           xml:space CDATA #FIXED "preserve">
 
 <!ELEMENT softbreak EMPTY>


### PR DESCRIPTION
This is a follow-up to d6fe59b314e7a2b610655d4664858afb30fc069c (see also #820).

Currently I see the following error while using Jing.

```
/path/to/CommonMark.dtd:50:11: fatal: The declaration for element type "text" must end with '>'.
```
